### PR TITLE
Updated goto.zsh to support zsh beginning search

### DIFF
--- a/.zsh/goto.zsh
+++ b/.zsh/goto.zsh
@@ -1,4 +1,11 @@
 autoload -Uz compinit
 compinit
 
+autoload -U up-line-or-beginning-search
+autoload -U down-line-or-beginning-search
+zle -N up-line-or-beginning-search
+zle -N down-line-or-beginning-search
+bindkey "^[[A" up-line-or-beginning-search
+bindkey "^[[B" down-line-or-beginning-search
+
 source $(brew --prefix)/etc/bash_completion.d/goto.sh


### PR DESCRIPTION
One of my favorite features of zsh is history-beginning-search which can be done backward or forward in this commit I enabled this feature.